### PR TITLE
[INTERNAL] Change UI5 cdn URL

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -41,7 +41,7 @@ It also requires the service worker cache configuration for the sources in `sap.
                         "type": "application"
                     },
                     {
-                        "url": "https://sapui5.hana.ondemand.com/resources",
+                        "url": "https://openui5.hana.ondemand.com/resources",
                         "type": "ui5resource"
                     }
                 ]
@@ -61,7 +61,7 @@ The types use different mechanisms to check if cached resources must be updated.
 Type `application` uses `applicationVersion` in the `manifest.json`, whereas `ui5resource` uses the version provided by `sap-ui-version.json`.
 
 Resources coming from URLs which start with `http://localhost:8080` use the `application` cache.
-Resources coming from URLs which start with `https://sapui5.hana.ondemand.com/resources` use the `ui5resource` cache.
+Resources coming from URLs which start with `https://openui5.hana.ondemand.com/resources` use the `ui5resource` cache.
 Each cache has its own versioning and the type of cache defines the specific update strategy.
 For instance, if a new application version was released, the `ui5resource` cache is unaffected whereas the `application` cache gets updated.
 
@@ -126,7 +126,7 @@ In order to load UI5 library resources from CDN:
 - `index.html`
     ```html
     <script id="sap-ui-bootstrap"
-        src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
+        src="https://openui5.hana.ondemand.com/resources/sap-ui-core.js"
         ... />
     ```
 
@@ -136,7 +136,7 @@ In order to load UI5 library resources from CDN:
     Configure your UI5 project accordingly, such that only async requests are used. Consult the UI5 framework documentation for more information, e.g.
     * [Use Asynchronous Loading](https://openui5.hana.ondemand.com/#/topic/676b636446c94eada183b1218a824717)
     * [Is Your Application Ready for Asynchronous Loading?](https://openui5.hana.ondemand.com/topic/493a15aa978d4fe9a67ea9407166eb01)
-    * [Performance Checklist](https://sapui5.hana.ondemand.com/#/topic/9c6400eb7dc145b78e94a81e6e390780)
+    * [Performance Checklist](https://openui5.hana.ondemand.com/#/topic/9c6400eb7dc145b78e94a81e6e390780)
 
 1. Additionally, it only works in combination with https. See for instance:
     *  [Using Service Workers](https://developer.mozilla.org/docs/Web/API/Service_Worker_API/Using_Service_Workers)

--- a/openui5-sample-app/webapp/index-cdn.html
+++ b/openui5-sample-app/webapp/index-cdn.html
@@ -8,7 +8,7 @@
 	<script src="regsw.js"></script>
 
 	<script id="sap-ui-bootstrap"
-		src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
+		src="https://openui5.hana.ondemand.com/resources/sap-ui-core.js"
 		data-sap-ui-libs="sap.m"
 		data-sap-ui-xx-waitForTheme="true"
 		data-sap-ui-theme="sap_fiori_3"

--- a/openui5-sample-app/webapp/manifest.json
+++ b/openui5-sample-app/webapp/manifest.json
@@ -14,7 +14,7 @@
 					"type": "application"
 				},
 				{
-					"url": "https://sapui5.hana.ondemand.com/resources",
+					"url": "https://openui5.hana.ondemand.com/resources",
 					"type": "ui5resource"
 				}
 			]

--- a/ui5-service-worker/README.md
+++ b/ui5-service-worker/README.md
@@ -54,7 +54,7 @@ In the service worker (file `sw.js`) the configuration can be initialized from t
 self.worker.initFromManifest();
 ```
 
-The example below will *precache* two URLs `https://localhost:8443/controller/App.controller.js` and `https://localhost:8443/view/App.view.xml`. Moreover, it uses a *static cache* for `https://localhost:8443/index`, and a *resource cache*, which checks the version for updates via `https://sapui5.hana.ondemand.com/resources`
+The example below will *precache* two URLs `https://localhost:8443/controller/App.controller.js` and `https://localhost:8443/view/App.view.xml`. Moreover, it uses a *static cache* for `https://localhost:8443/index`, and a *resource cache*, which checks the version for updates via `https://openui5.hana.ondemand.com/resources`
 
 - `sw.js`
     ```js
@@ -80,7 +80,7 @@ The example below will *precache* two URLs `https://localhost:8443/controller/Ap
                         "type": "static"
                     },
                     {
-                        "url": "https://sapui5.hana.ondemand.com/resources",
+                        "url": "https://openui5.hana.ondemand.com/resources",
                         "type": "ui5resource"
                     },
                     {
@@ -106,7 +106,7 @@ self.worker.init([]);
 ```
 
 The example below will *precache* two URLs `https://localhost:8443/controller/App.controller.js` and `https://localhost:8443/view/App.view.xml`. It uses a *static cache* for `https://localhost:8443/index`
-and a *resource cache*, which checks the version for updates via `https://sapui5.hana.ondemand.com/resources`
+and a *resource cache*, which checks the version for updates via `https://openui5.hana.ondemand.com/resources`
 
 - `sw.js`
     ```javascript
@@ -121,7 +121,7 @@ and a *resource cache*, which checks the version for updates via `https://sapui5
         url: "https://localhost:8443/index",
         type: "static"
     }, {
-        url: "https://sapui5.hana.ondemand.com/resources",
+        url: "https://openui5.hana.ondemand.com/resources",
         type: "ui5resource"
     }]).then(() => {
         console.log("successfully initialized");
@@ -170,7 +170,7 @@ It uses field `version` in `sap-ui-version.json` for the version comparison.
 
 ```json
 {
-    "url": "https://sapui5.hana.ondemand.com/resources",
+    "url": "https://openui5.hana.ondemand.com/resources",
     "type": "ui5resource"
 }
 ```


### PR DESCRIPTION
Use openui5.hana.ondemand.com as CDN URL because
the openui5-sample-app is based on the openui5 resources.
sapui5 resources should not be required and this is also
a license violation.